### PR TITLE
Optimization:  Return a Cow from lexiclean()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ use std::{
   path::{Component, Path},
 };
 
-pub trait Lexiclean : ToOwned {
+pub trait Lexiclean: ToOwned {
   fn lexiclean(&self) -> Cow<'_, Self>;
 }
 


### PR DESCRIPTION
With this, when the input is unchanged, `lexiclean()` can return a reference to the original input `Path` instead of having to allocate a new `PathBuf` :)